### PR TITLE
Fix: Update image path in index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -33,6 +33,6 @@ ok <!DOCTYPE html>
 </head>
 <body>
     <h1>Cory Richard</h1>
-    <img src="https://github.com/RSOS-ops/coryrichardlanding/blob/12485b46d45de3384075306f1d2c47a2e8c7847c/IMG_0435.png" alt="Cory Richard pill">
+    <img src="IMG_0435.png" alt="Cory Richard pill">
 </body>
 </html>


### PR DESCRIPTION
I changed the src attribute of the img tag to use a relative path (IMG_0435.png) instead of an absolute GitHub URL.
This resolves the issue where the image was not displaying on the page.