### PR TITLE
Fix: Update image path in index.html to display correctly

### DIFF
--- a/index.html
+++ b/index.html
@@ -33,6 +33,6 @@
 </head>
 <body>
     <h1>Cory Richard</h1>
-    <img src="https://github.com/RSOS-ops/coryrichardlanding/gh-pages/IMG_0435.png" alt="Cory Richard pill">
+    <img src="IMG_0435.jpeg" alt="Cory Richard pill">
 </body>
 </html>


### PR DESCRIPTION
The image on the landing page was not displaying because the src attribute in the img tag was pointing to an incorrect file extension (.png instead of .jpeg) and used an absolute URL. This commit changes the src attribute to use the correct relative path 'IMG_0435.jpeg'.