### PR TITLE
Increase particle density for better text legibility

### DIFF
--- a/index.html
+++ b/index.html
@@ -320,8 +320,8 @@
               this.engine.fillRect(
                 pos.x * this.width,
                 pos.y * this.height,
-                this.width / 150,
-                this.width / 150
+                this.width / 100,
+                this.width / 100
               );
 
               if (i % 2) {
@@ -348,8 +348,8 @@
                 this.engine.fillRect(
                   pos.x * this.width - padding,
                   pos.y * this.height - padding,
-                  this.width / 150 + padding * 2,
-                  this.width / 150 + padding * 2
+                  this.width / 100 + padding * 2,
+                  this.width / 100 + padding * 2
                 );
               }
             });


### PR DESCRIPTION
I modified the drawStatic method in index.html to improve the legibility of the text elements, particularly "DJ music visual tech".

The size of the static particles that form the text mask was increased by changing the divisor from 150 to 100 (i.e., this.width / 150 became this.width / 100). This makes the individual particles larger, creating a denser and more readable text effect.