### PR TITLE
Fix: Reduce particle glow size to mitigate text blur

### DIFF
--- a/index.html
+++ b/index.html
@@ -340,13 +340,13 @@
                 return;
               }
 
-              pos.o += step;
+              pos.o += step; // Animation re-enabled
               const opa = Math.max(0, Math.sin(pos.o * Math.PI * 2));
-              const padding = opa * baseParticleWidth * 1.5;
+              const padding = opa * baseParticleWidth * 0.5; // Glow size reduced
 
               this.engine.fillStyle = color(subMask.hsl, this.opa * opa * 0.2);
 
-              if (pos.t < 0.5) {
+              if (pos.t < 0.5) { // This draws a circular glow
                 this.engine.beginPath();
                 this.engine.arc(
                   pos.x * this.width,
@@ -356,7 +356,7 @@
                   Math.PI * 2
                 );
                 this.engine.fill();
-              } else {
+              } else { // This draws a rectangular glow
                 this.engine.fillRect(
                   pos.x * this.width - padding,
                   pos.y * this.height - padding,


### PR DESCRIPTION
Addresses your feedback regarding circular particles blurring the text. The chosen solution is to reduce the size of the glowing effect around particles, rather than removing circular particles or their animation entirely.

Specifically, the `padding` calculation in the `drawStatic` method, which determines the extent of the glow, has been changed from `opa * baseParticleWidth * 1.5` to `opa * baseParticleWidth * 0.5`.

This makes the glow tighter around each particle, reducing overlap and the perceived blurring effect, while retaining the existing particle shapes and animations.