### PR TITLE
Feat: Add text outline for improved legibility

### DIFF
--- a/index.html
+++ b/index.html
@@ -172,6 +172,9 @@
               engine.clearRect(0, 0, canvasWidth, canvasHeight);
               engine.font = font(fSizeMain);
               engine.fillText(textStack.text, currentXMainName, yMainName);
+              engine.strokeStyle = '#FFFFFF'; // White stroke color
+              engine.lineWidth = 1;           // 1px line width
+              engine.strokeText(textStack.text, currentXMainName, yMainName); // Draw the stroke
               const textPartWidth = engine.measureText(textStack.text).width;
               const data = engine.getImageData(0, 0, canvasWidth, canvasHeight);
               const subStack = [];
@@ -215,6 +218,9 @@
               engine.clearRect(0, 0, canvasWidth, canvasHeight);
               engine.font = font(fSizeSections);
               engine.fillText(textStack.text, currentXSections, ySections);
+              engine.strokeStyle = '#FFFFFF'; // White stroke color
+              engine.lineWidth = 1;           // 1px line width
+              engine.strokeText(textStack.text, currentXSections, ySections); // Draw the stroke
               const textPartWidth = engine.measureText(textStack.text).width;
               const data = engine.getImageData(0, 0, canvasWidth, canvasHeight);
               const subStack = [];


### PR DESCRIPTION
Enhanced the legibility of all text elements by adding an outline effect.

This was achieved by modifying the `buildTextMask` method. For each text segment (both main name and sections), after the standard `fillText` call on the temporary canvas, `strokeText` is now also called. A 1px white stroke is applied.

This ensures that the subsequent particle position sampling (`getImageData`) picks up points from this outline, resulting in particles forming a more defined shape for all text on the site.