### PR TITLE
Fix: Reposition 'CORY RICHARD' text to the very top

### DIFF
--- a/index.html
+++ b/index.html
@@ -167,7 +167,7 @@
             engine.font = font(fSizeMain);
             mMain = engine.measureText(mainNameString);
             const fontWidthMain = mMain.width;
-            const yMainName = canvasHeight / 4; // Adjusted for new layout
+            const yMainName = 10; // Position 10px from the top of the temporary canvas
             let currentXMainName = (canvasWidth - fontWidthMain) / 2;
 
             mainNameTexts.forEach(textStack => {


### PR DESCRIPTION
Adjusts the vertical alignment of the 'main-name' text role (e.g., 'CORY RICHARD') to position it closer to the top edge of the animation area.

This change was made to increase the visual separation between the top text ('CORY RICHARD') and the center text ('COMING SOON').

In `buildTextMask`:
- The `yMainName` coordinate for `mainNameTexts` has been changed from `canvasHeight / 4` to `10` (pixels from the top).
- `engine.textBaseline = 'top'` remains in use for this role.

Other text elements ('center-name' and 'sections') retain their previous positioning.