### PR TITLE
Fix: Reposition 'DJ Music Visual Tech' text to the very bottom

### DIFF
--- a/index.html
+++ b/index.html
@@ -257,13 +257,13 @@
             fSizeSections = Math.max(fSizeSections, 1);
             engine.font = font(fSizeSections);
             const fontWidthSections = engine.measureText(sectionsString).width;
-            const ySections = canvasHeight * 0.75; // Adjusted for better centering
+            const ySections = canvasHeight - 10; // Position 10px from the bottom
             let currentXSections = (canvasWidth - fontWidthSections) / 2;
 
             sectionsTexts.forEach(textStack => {
               engine.clearRect(0, 0, canvasWidth, canvasHeight);
               engine.font = font(fSizeSections);
-              engine.textBaseline = 'middle'; // Added for better centering
+              engine.textBaseline = 'bottom'; // Position 10px from the bottom
               engine.fillText(textStack.text, currentXSections, ySections);
               engine.strokeStyle = '#FFFFFF'; // White stroke color
               engine.lineWidth = 1;           // 1px line width


### PR DESCRIPTION
Adjusts the vertical alignment of the 'sections' text role (e.g., 'DJ Music Visual Tech') to position it closer to the bottom edge of the animation area.

This change provides a more spread-out layout with text at the top, center, and bottom of the screen.

In `buildTextMask`:
- The `ySections` coordinate for `sectionsTexts` has been changed from `canvasHeight * 0.75` to `canvasHeight - 10` (pixels from the bottom).
- `engine.textBaseline` for this role has been changed from 'middle' to 'bottom'.

Other text elements ('main-name' at top and 'center-name' at center) retain their previous positioning.