### PR TITLE
Fix: Reduce font size and center "COMING SOON" text

### DIFF
--- a/script.js
+++ b/script.js
@@ -173,26 +173,31 @@ class TextSparks {
     // Process 'center-name' texts
     if (centerNameTexts.length > 0) {
       const centerNameString = centerNameTexts.map(t => t.text).join('');
-      const baseCenterFontSize = 40;
+      const baseCenterFontSize = 40 / 3;
       tempEngine.font = font(baseCenterFontSize);
       let metrics = tempEngine.measureText(centerNameString);
       let fSizeCenterName = Math.min(baseCenterFontSize, (canvasWidth * 0.9 / metrics.width) * baseCenterFontSize);
       fSizeCenterName = Math.max(fSizeCenterName, 1); // Ensure font size is at least 1
       const currentFontStyle = font(fSizeCenterName);
       metrics = tempEngine.measureText(centerNameString); // Re-measure
-      const fontWidthCenter = metrics.width;
+      // const fontWidthCenter = metrics.width; // Not needed with textAlign='center'
       const yCenterName = canvasHeight / 2;
-      let currentXCenterName = (canvasWidth - fontWidthCenter) / 2;
+      let currentXCenterName = canvasWidth / 2; // Adjusted for textAlign='center'
+
+      tempEngine.textAlign = 'center'; // Added for horizontal centering
+      tempEngine.textBaseline = 'middle'; // Ensure effective
 
       centerNameTexts.forEach(textStack => {
-        tempEngine.textBaseline = 'middle';
+        // The x position passed to _createTextParticles should be the centered X.
+        // For a single "COMING SOON" item, the loop runs once.
         mask.push(this._createTextParticles(tempEngine, textStack.text, currentFontStyle, currentXCenterName, yCenterName, canvasWidth, canvasHeight, false, textStack.hsl));
-        currentXCenterName += tempEngine.measureText(textStack.text).width;
+        // currentXCenterName += tempEngine.measureText(textStack.text).width; // Removed: Problematic with textAlign='center' and not needed for single item.
       });
     }
 
     // Process 'sections' texts
     if (sectionsTexts.length > 0) {
+      tempEngine.textAlign = 'start'; // Reset textAlign to default for sectionsTexts
       const sectionsString = sectionsTexts.map(t => t.text).join(' '); // Join with spaces for better measurement
       let fSizeMainVal = 30; // Default if mainNameTexts was empty or font not parsed
       if (mainNameTexts.length > 0) {


### PR DESCRIPTION
- I reduced the font size of the "COMING SOON" text (data-role="center-name") to one-third of its original size by changing baseCenterFontSize from 40 to 40/3 in script.js.
- I ensured "COMING SOON" text is accurately centered by:
  - Setting canvas context textAlign to 'center'.
  - Setting canvas context textBaseline to 'middle'.
  - Calculating the X coordinate for fillText as canvasWidth / 2.
- I added textAlign = 'start' for "sections" text block to prevent style persistence from the "COMING SOON" text block, ensuring other text layouts remain unaffected.