### PR TITLE
Here's the revised message:

### DIFF
--- a/script.js
+++ b/script.js
@@ -293,28 +293,49 @@ class TextSparks {
    * Creates new animated particles based on the current text mask.
    */
   createNewParticle() {
-    if (!this.permanentTextMask || this.permanentTextMask.length === 0) {
-      return; // Don't create particles if permanent text mask isn't available
+    // Generate from permanent text (e.g., "COMING SOON")
+    if (this.permanentTextMask && this.permanentTextMask.length > 0) {
+      for (let i = 0; i < newParticlesPerFrame; i++) {
+        // Pick a random sub-mask (character/section) from the permanent text mask
+        // this.permanentTextMask is an array of subMasks, for "COMING SOON" it's likely just one.
+        const subMask = this.permanentTextMask[Math.random() * this.permanentTextMask.length | 0];
+
+        if (!subMask || !subMask.s || subMask.s.length === 0) continue; // Skip if subMask is empty
+        
+        // Pick a random particle position from the sub-mask
+        const maskElement = subMask.s[Math.random() * subMask.s.length | 0];
+
+        if (maskElement) {
+          const particle = {
+            x: maskElement.x, // Initial position from mask
+            y: maskElement.y,
+            hsl: subMask.hsl, // Color from mask (permanent text HSL)
+            c: this.prepareParticle // Initial behavior function for the particle
+          };
+          this.particleMap.set(particle, particle); // Add to active particles
+        }
+      }
     }
 
-    for (let i = 0; i < newParticlesPerFrame; i++) {
-      // Pick a random sub-mask (character/section) from the permanent text mask
-      // this.permanentTextMask is an array of subMasks, for "COMING SOON" it's likely just one.
-      const subMask = this.permanentTextMask[Math.random() * this.permanentTextMask.length | 0];
+    // Generate from active cycling text
+    if (this.mask && this.mask.length > 0 && this.opa > 0.1) {
+      for (let i = 0; i < newParticlesPerFrame; i++) {
+        const subMask = this.mask[Math.random() * this.mask.length | 0];
 
-      if (!subMask || !subMask.s || subMask.s.length === 0) continue; // Skip if subMask is empty
+        if (!subMask || !subMask.s || subMask.s.length === 0) continue; // Skip if subMask is empty
 
-      // Pick a random particle position from the sub-mask
-      const maskElement = subMask.s[Math.random() * subMask.s.length | 0];
+        // Pick a random particle position from the sub-mask
+        const maskElement = subMask.s[Math.random() * subMask.s.length | 0];
 
-      if (maskElement) {
-        const particle = {
-          x: maskElement.x, // Initial position from mask
-          y: maskElement.y,
-          hsl: subMask.hsl, // Color from mask
-          c: this.prepareParticle // Initial behavior function for the particle
-        };
-        this.particleMap.set(particle, particle); // Add to active particles
+        if (maskElement) {
+          const particle = {
+            x: maskElement.x, // Initial position from mask
+            y: maskElement.y,
+            hsl: subMask.hsl, // Color from mask (cycling text HSL)
+            c: this.prepareParticle // Initial behavior function for the particle
+          };
+          this.particleMap.set(particle, particle); // Add to active particles
+        }
       }
     }
   }


### PR DESCRIPTION
Feat: Enable particle emanation from all active texts

I've modified `createNewParticle` in `script.js` to allow all visible text elements to emanate particles:

- Particles continue to emanate from the static "COMING SOON" text (`this.permanentTextMask`) as white particles.
- I added logic to also emanate particles from the currently active cycling text (`this.mask`) if it's visible (this.opa > 0.1). These particles will use the HSL colors of the active cycling text.
- Each active source (static "COMING SOON" and/or the current cycling text) will generate up to `newParticlesPerFrame` particles. This means particle density may increase when a cycling text is displayed.

This change ensures that both the static "COMING SOON" text and any currently displayed cycling text will actively emanate particles, addressing your feedback that all text should have this effect.